### PR TITLE
Potential fix for code scanning alert no. 1: Use of externally-controlled format string

### DIFF
--- a/actions/product.action.ts
+++ b/actions/product.action.ts
@@ -147,7 +147,7 @@ export async function getProductsCount(type: ProductCountType = ProductCountType
       count
     };
   } catch (error) {
-    console.error(`Erro ao contar produtos (${type}):`, error);
+    console.error("Erro ao contar produtos (%s):", type, error);
 
     return {
       success: false,


### PR DESCRIPTION
Potential fix for [https://github.com/GabrielSchiavo/smartstock/security/code-scanning/1](https://github.com/GabrielSchiavo/smartstock/security/code-scanning/1)

To fix the problem, we should avoid passing user-controlled data as part of the format string in logging functions like `console.error`. Instead, we should use a static format string and pass the user-controlled data as a separate argument, ensuring it is treated as a value rather than as part of the format string. Specifically, in actions/product.action.ts, line 150 should be changed from:

```ts
console.error(`Erro ao contar produtos (${type}):`, error);
```

to:

```ts
console.error("Erro ao contar produtos (%s):", type, error);
```

This change ensures that any value of `type` is safely inserted into the log message without being interpreted as a format specifier. No additional imports or definitions are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
